### PR TITLE
Fixes issue with headless mode

### DIFF
--- a/addons/GDTask/GDTask.Delay.cs
+++ b/addons/GDTask/GDTask.Delay.cs
@@ -253,6 +253,7 @@ namespace Fractural.Tasks
                 TaskPool.RegisterSizeGetter(typeof(NextFramePromise), () => pool.Size);
             }
 
+            bool isMainThread;
             ulong frameCount;
             CancellationToken cancellationToken;
             GDTaskCompletionSourceCore<AsyncUnit> core;
@@ -273,7 +274,9 @@ namespace Fractural.Tasks
                     result = new NextFramePromise();
                 }
 
-                result.frameCount = GDTaskPlayerLoopAutoload.IsMainThread ? Engine.GetProcessFrames() : 0ul;
+                result.isMainThread = GDTaskPlayerLoopAutoload.IsMainThread;
+                if (result.isMainThread)
+                    result.frameCount = Engine.GetProcessFrames();
                 result.cancellationToken = cancellationToken;
 
                 TaskTracker.TrackActiveTask(result, 3);
@@ -319,7 +322,7 @@ namespace Fractural.Tasks
                     return false;
                 }
 
-                if (frameCount == Engine.GetProcessFrames())
+                if (isMainThread && frameCount == Engine.GetProcessFrames())
                 {
                     return true;
                 }
@@ -348,6 +351,7 @@ namespace Fractural.Tasks
                 TaskPool.RegisterSizeGetter(typeof(DelayFramePromise), () => pool.Size);
             }
 
+            bool isMainThread;
             ulong initialFrame;
             int delayFrameCount;
             CancellationToken cancellationToken;
@@ -373,7 +377,9 @@ namespace Fractural.Tasks
 
                 result.delayFrameCount = delayFrameCount;
                 result.cancellationToken = cancellationToken;
-                result.initialFrame = GDTaskPlayerLoopAutoload.IsMainThread ? Engine.GetProcessFrames() : 0ul;
+                result.isMainThread = GDTaskPlayerLoopAutoload.IsMainThread;
+                if (result.isMainThread)
+                    result.initialFrame = Engine.GetProcessFrames();
 
                 TaskTracker.TrackActiveTask(result, 3);
 
@@ -427,7 +433,7 @@ namespace Fractural.Tasks
                     }
 
                     // skip in initial frame.
-                    if (initialFrame == Engine.GetProcessFrames())
+                    if (isMainThread && initialFrame == Engine.GetProcessFrames())
                     {
 #if DEBUG
                         // force use Realtime.
@@ -476,6 +482,7 @@ namespace Fractural.Tasks
                 TaskPool.RegisterSizeGetter(typeof(DelayPromise), () => pool.Size);
             }
 
+            bool isMainThread;
             ulong initialFrame;
             double delayTimeSpan;
             double elapsed;
@@ -502,7 +509,9 @@ namespace Fractural.Tasks
                 result.elapsed = 0.0f;
                 result.delayTimeSpan = (float)delayTimeSpan.TotalSeconds;
                 result.cancellationToken = cancellationToken;
-                result.initialFrame = GDTaskPlayerLoopAutoload.IsMainThread ? Engine.GetProcessFrames() : 0ul;
+                result.isMainThread = GDTaskPlayerLoopAutoload.IsMainThread;
+                if (result.isMainThread)
+                    result.initialFrame = Engine.GetProcessFrames();
 
                 TaskTracker.TrackActiveTask(result, 3);
 
@@ -549,7 +558,7 @@ namespace Fractural.Tasks
 
                 if (elapsed == 0.0f)
                 {
-                    if (initialFrame == Engine.GetProcessFrames())
+                    if (isMainThread && initialFrame == Engine.GetProcessFrames())
                     {
                         return true;
                     }

--- a/addons/GDTask/GDTask.Delay.cs
+++ b/addons/GDTask/GDTask.Delay.cs
@@ -253,7 +253,7 @@ namespace Fractural.Tasks
                 TaskPool.RegisterSizeGetter(typeof(NextFramePromise), () => pool.Size);
             }
 
-            int frameCount;
+            ulong frameCount;
             CancellationToken cancellationToken;
             GDTaskCompletionSourceCore<AsyncUnit> core;
 
@@ -273,7 +273,7 @@ namespace Fractural.Tasks
                     result = new NextFramePromise();
                 }
 
-                result.frameCount = GDTaskPlayerLoopAutoload.IsMainThread ? Engine.GetFramesDrawn() : -1;
+                result.frameCount = GDTaskPlayerLoopAutoload.IsMainThread ? Engine.GetProcessFrames() : 0ul;
                 result.cancellationToken = cancellationToken;
 
                 TaskTracker.TrackActiveTask(result, 3);
@@ -319,7 +319,7 @@ namespace Fractural.Tasks
                     return false;
                 }
 
-                if (frameCount == Engine.GetFramesDrawn())
+                if (frameCount == Engine.GetProcessFrames())
                 {
                     return true;
                 }
@@ -348,7 +348,7 @@ namespace Fractural.Tasks
                 TaskPool.RegisterSizeGetter(typeof(DelayFramePromise), () => pool.Size);
             }
 
-            int initialFrame;
+            ulong initialFrame;
             int delayFrameCount;
             CancellationToken cancellationToken;
 
@@ -373,7 +373,7 @@ namespace Fractural.Tasks
 
                 result.delayFrameCount = delayFrameCount;
                 result.cancellationToken = cancellationToken;
-                result.initialFrame = GDTaskPlayerLoopAutoload.IsMainThread ? Engine.GetFramesDrawn() : -1;
+                result.initialFrame = GDTaskPlayerLoopAutoload.IsMainThread ? Engine.GetProcessFrames() : 0ul;
 
                 TaskTracker.TrackActiveTask(result, 3);
 
@@ -427,7 +427,7 @@ namespace Fractural.Tasks
                     }
 
                     // skip in initial frame.
-                    if (initialFrame == Engine.GetFramesDrawn())
+                    if (initialFrame == Engine.GetProcessFrames())
                     {
 #if DEBUG
                         // force use Realtime.
@@ -476,7 +476,7 @@ namespace Fractural.Tasks
                 TaskPool.RegisterSizeGetter(typeof(DelayPromise), () => pool.Size);
             }
 
-            int initialFrame;
+            ulong initialFrame;
             double delayTimeSpan;
             double elapsed;
             CancellationToken cancellationToken;
@@ -502,7 +502,7 @@ namespace Fractural.Tasks
                 result.elapsed = 0.0f;
                 result.delayTimeSpan = (float)delayTimeSpan.TotalSeconds;
                 result.cancellationToken = cancellationToken;
-                result.initialFrame = GDTaskPlayerLoopAutoload.IsMainThread ? Engine.GetFramesDrawn() : -1;
+                result.initialFrame = GDTaskPlayerLoopAutoload.IsMainThread ? Engine.GetProcessFrames() : 0ul;
 
                 TaskTracker.TrackActiveTask(result, 3);
 
@@ -549,7 +549,7 @@ namespace Fractural.Tasks
 
                 if (elapsed == 0.0f)
                 {
-                    if (initialFrame == Engine.GetFramesDrawn())
+                    if (initialFrame == Engine.GetProcessFrames())
                     {
                         return true;
                     }

--- a/addons/GDTask/PlayerLoopTimer.cs
+++ b/addons/GDTask/PlayerLoopTimer.cs
@@ -142,6 +142,7 @@ namespace Fractural.Tasks
 
     sealed class DeltaTimePlayerLoopTimer : PlayerLoopTimer
     {
+        bool isMainThread;
         ulong initialFrame;
         double elapsed;
         double interval;
@@ -156,7 +157,7 @@ namespace Fractural.Tasks
         {
             if (elapsed == 0.0)
             {
-                if (initialFrame == Engine.GetProcessFrames())
+                if (isMainThread && initialFrame == Engine.GetProcessFrames())
                 {
                     return true;
                 }
@@ -174,7 +175,8 @@ namespace Fractural.Tasks
         protected override void ResetCore(TimeSpan? interval)
         {
             this.elapsed = 0.0;
-            this.initialFrame = GDTaskPlayerLoopAutoload.IsMainThread ? Engine.GetProcessFrames() : 0ul;
+            this.isMainThread = GDTaskPlayerLoopAutoload.IsMainThread;
+            this.initialFrame = Engine.GetProcessFrames();
             if (interval != null)
             {
                 this.interval = (float)interval.Value.TotalSeconds;

--- a/addons/GDTask/PlayerLoopTimer.cs
+++ b/addons/GDTask/PlayerLoopTimer.cs
@@ -176,7 +176,8 @@ namespace Fractural.Tasks
         {
             this.elapsed = 0.0;
             this.isMainThread = GDTaskPlayerLoopAutoload.IsMainThread;
-            this.initialFrame = Engine.GetProcessFrames();
+            if (this.isMainThread)
+                this.initialFrame = Engine.GetProcessFrames();
             if (interval != null)
             {
                 this.interval = (float)interval.Value.TotalSeconds;

--- a/addons/GDTask/PlayerLoopTimer.cs
+++ b/addons/GDTask/PlayerLoopTimer.cs
@@ -142,7 +142,7 @@ namespace Fractural.Tasks
 
     sealed class DeltaTimePlayerLoopTimer : PlayerLoopTimer
     {
-        int initialFrame;
+        ulong initialFrame;
         double elapsed;
         double interval;
 
@@ -156,7 +156,7 @@ namespace Fractural.Tasks
         {
             if (elapsed == 0.0)
             {
-                if (initialFrame == Engine.GetFramesDrawn())
+                if (initialFrame == Engine.GetProcessFrames())
                 {
                     return true;
                 }
@@ -174,7 +174,7 @@ namespace Fractural.Tasks
         protected override void ResetCore(TimeSpan? interval)
         {
             this.elapsed = 0.0;
-            this.initialFrame = GDTaskPlayerLoopAutoload.IsMainThread ? Engine.GetFramesDrawn() : -1;
+            this.initialFrame = GDTaskPlayerLoopAutoload.IsMainThread ? Engine.GetProcessFrames() : 0ul;
             if (interval != null)
             {
                 this.interval = (float)interval.Value.TotalSeconds;


### PR DESCRIPTION
Fixes #5 

Currently, some APIs inside GDTask rely on the `Engine.GetFramesDrawn()` API, which always returns 0 when Engine runs with `--disable-render-loop`, this PR replaces all usage mentioned with `Engine.GetProcessFrames()`, which works regardless whether the render loop is enabled.
This API is also a better candidate for Unity's `Time.frameCount` API.

However, `Engine.GetProcessFrames()` returns `ulong`, which does not have `-1` as a fallback value, I have replaced all `-1`s with `0ul` as a compromise, this could be an issue for some edge cases. Currently, I can pass the builtin test, but I think further tests are required.

```csharp
// UniTask: PlayerLoopTimer.cs, line 159

protected override bool MoveNextCore()
{
    if (elapsed == 0.0f)
    {
        if (initialFrame == Time.frameCount)
        {
            return true;
        }
    }

    elapsed += Time.deltaTime;
    if (elapsed >= interval)
    {
        return false;
    }

    return true;
}

protected override void ResetCore(TimeSpan? interval)
{
    this.elapsed = 0.0f;
    this.initialFrame = PlayerLoopHelper.IsMainThread ? Time.frameCount : -1;
    if (interval != null)
    {
        this.interval = (float)interval.Value.TotalSeconds;
    }
}
```

```csharp
// GDTask: PlayerLoopTimer.cs, line 155

protected override bool MoveNextCore()
{
    if (elapsed == 0.0)
    {
        if (initialFrame == Engine.GetProcessFrames())
        {
            return true;
        }
    }

    elapsed += GDTaskPlayerLoopAutoload.Global.DeltaTime;
    if (elapsed >= interval)
    {
        return false;
    }

    return true;
}

protected override void ResetCore(TimeSpan? interval)
{
    this.elapsed = 0.0;
    this.initialFrame = GDTaskPlayerLoopAutoload.IsMainThread ? Engine.GetProcessFrames() : 0ul;
    if (interval != null)
    {
        this.interval = (float)interval.Value.TotalSeconds;
    }
}
```