### PR TITLE
Fix broken Node.AwakeAsync

### DIFF
--- a/addons/GDTask/Triggers/AsyncEnterTreeTrigger.cs
+++ b/addons/GDTask/Triggers/AsyncEnterTreeTrigger.cs
@@ -13,6 +13,12 @@ namespace Fractural.Tasks.Triggers
 
     public sealed partial class AsyncEnterTreeTrigger : AsyncTriggerBase<AsyncUnit>
     {
+        public override void _EnterTree()
+        {
+            base._EnterTree();
+            RaiseEvent(AsyncUnit.Default);
+        }
+
         public GDTask AwakeAsync()
         {
             if (calledEnterTree) return GDTask.CompletedTask;


### PR DESCRIPTION
This issue is discovered when writing tests for `GDTask.Nuget`, previously, `AsyncEnterTreeTrigger` never calls `RaiseEvent(AsyncUnit.Default)` on `_EnterTree`, which causes freezing when awaited.