### PR TITLE
Fixed warnings thrown when AOT enabled

### DIFF
--- a/addons/GDTask/Internal/DiagnosticsExtensions.cs
+++ b/addons/GDTask/Internal/DiagnosticsExtensions.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -43,7 +44,8 @@ namespace Fractural.Tasks.Internal
             { typeof(GDTaskVoid), "GDTaskVoid" }
         };
 
-        public static string CleanupAsyncStackTrace(this StackTrace stackTrace)
+		[RequiresUnreferencedCode("Calls System.Diagnostics.StackFrame.GetMethod()")]
+		public static string CleanupAsyncStackTrace(this StackTrace stackTrace)
         {
             if (stackTrace == null) return "";
 
@@ -120,15 +122,15 @@ namespace Fractural.Tasks.Internal
             return sb.ToString();
         }
 
-
         static bool IsAsync(MethodBase methodInfo)
         {
             var declareType = methodInfo.DeclaringType;
             return typeof(IAsyncStateMachine).IsAssignableFrom(declareType);
         }
 
-        // code from Ben.Demystifier/EnhancedStackTrace.Frame.cs
-        static bool TryResolveStateMachineMethod(ref MethodBase method, out Type declaringType)
+		// code from Ben.Demystifier/EnhancedStackTrace.Frame.cs
+		[RequiresUnreferencedCode("Calls System.Type.GetMethods()")]
+		static bool TryResolveStateMachineMethod(ref MethodBase method, out Type declaringType)
         {
             declaringType = method.DeclaringType;
 


### PR DESCRIPTION
There are two warnings thrown when using TargetFramework Net8.0 and setting PublishAOT=true. This change should fix it for non-DEBUG builds. For debug builds you would not normally enable AOT.

The warnings are:
```
Warning	IL2026	Using member 'System.Diagnostics.StackFrame.GetMethod()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Metadata for the method might be incomplete or removed.	
\GDTask\Internal\DiagnosticsExtensions.cs	57	Active	

Warning	IL2075	'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods', 'DynamicallyAccessedMemberTypes.NonPublicMethods' in call to 'System.Type.GetMethods(BindingFlags)'. The return value of method 'System.Type.DeclaringType.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.	
\GDTask\Internal\DiagnosticsExtensions.cs	143	Active	
```

By ading the `RequiresUnreferencedCode` attribute to these two functions it bascially moves the problem on to the caller of these. The caller `TaskTracker::TrackActiveTask()` which is DEBUG function and thus disabled in `ExportRelease` builds, "fixing" the issue.

Not sure if this is the best way to deal with these warnings but seems to work. Also would not fix the "problem" for debug builds that has PublishAOT enabled and will cause this warning in that case.

```
Warning	IL2026	Using member 'Fractural.Tasks.Internal.DiagnosticsExtensions.CleanupAsyncStackTrace(StackTrace)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Calls System.Diagnostics.StackFrame.GetMethod().	
\GDTask\Internal\TaskTracker.cs	72	Active	
```
