### PR TITLE
Frame delays with optional delta return

### DIFF
--- a/addons/GDTask/GDTask.Delay.cs
+++ b/addons/GDTask/GDTask.Delay.cs
@@ -41,23 +41,7 @@ namespace Fractural.Tasks
         /// <summary>
         /// Similar as GDTask.Yield but guaranteed run on next frame.
         /// </summary>
-        public static GDTask NextFrame()
-        {
-            return new GDTask(NextFramePromise.Create(PlayerLoopTiming.Process, CancellationToken.None, out var token), token);
-        }
-
-        /// <summary>
-        /// Similar as GDTask.Yield but guaranteed run on next frame.
-        /// </summary>
-        public static GDTask NextFrame(PlayerLoopTiming timing)
-        {
-            return new GDTask(NextFramePromise.Create(timing, CancellationToken.None, out var token), token);
-        }
-
-        /// <summary>
-        /// Similar as GDTask.Yield but guaranteed run on next frame.
-        /// </summary>
-        public static GDTask NextFrame(CancellationToken cancellationToken)
+        public static GDTask NextFrame(CancellationToken cancellationToken = default)
         {
             return new GDTask(NextFramePromise.Create(PlayerLoopTiming.Process, cancellationToken, out var token), token);
         }
@@ -65,7 +49,7 @@ namespace Fractural.Tasks
         /// <summary>
         /// Similar as GDTask.Yield but guaranteed run on next frame.
         /// </summary>
-        public static GDTask NextFrame(PlayerLoopTiming timing, CancellationToken cancellationToken)
+        public static GDTask NextFrame(PlayerLoopTiming timing, CancellationToken cancellationToken = default)
         {
             return new GDTask(NextFramePromise.Create(timing, cancellationToken, out var token), token);
         }

--- a/addons/GDTask/GDTask.DelayWithDelta.cs
+++ b/addons/GDTask/GDTask.DelayWithDelta.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading;
+
+
+namespace Fractural.Tasks;
+
+// ReSharper disable once InconsistentNaming
+public readonly partial struct GDTask
+{
+
+	/// <summary>
+	/// Similar as GDTask.Yield but guaranteed run on next frame.
+	/// <br/>
+	/// Runs in <see cref="PlayerLoopTiming"/>.<see cref="PlayerLoopTiming.Process"/>
+	/// </summary>
+	/// <param name="cancellationToken"> Optional cancellation token </param>
+	/// <returns>Delta time between frames</returns>
+	public static GDTask<double> NextFrameWithDelta(CancellationToken cancellationToken = default)
+		=> GDTask.NextFrameWithDelta(PlayerLoopTiming.Process, cancellationToken);
+	
+	
+	/// <summary>
+	/// Similar as GDTask.Yield but guaranteed run on next frame.
+	/// </summary>
+	/// <param name="timing"> <see cref="PlayerLoopTiming"/> of frames </param>
+	/// <param name="cancellationToken"> Optional cancellation token </param>
+	/// <returns> Delta time between frames </returns>
+	public static async GDTask<double> NextFrameWithDelta(PlayerLoopTiming timing, CancellationToken cancellationToken = default)
+	{
+		var beforeTime = DateTime.Now;
+		
+		await GDTask.NextFrame(timing, cancellationToken);
+
+		return (DateTime.Now - beforeTime).TotalSeconds;
+	}
+	
+	
+	/// <summary>
+	/// Waits <see cref="delayFrameCount"/> frames
+	/// </summary>
+	/// <param name="delayFrameCount">Amount of frames to wait</param>
+	/// <param name="delayTiming"><see cref="PlayerLoopTiming"/> of frames</param>
+	/// <param name="cancellationToken">Optional cancellation token</param>
+	/// <returns>Delta time of delay. Expect it to be greater then 1 if <see cref="delayFrameCount"/> greater then FPS</returns>
+	/// <exception cref="ArgumentOutOfRangeException"><see cref="delayFrameCount"/> less than 0 </exception>
+	public static async GDTask<double> DelayFrameWithDelta(int delayFrameCount, PlayerLoopTiming delayTiming = PlayerLoopTiming.Process, CancellationToken cancellationToken = default)
+	{
+		if (delayFrameCount < 0)
+			throw new ArgumentOutOfRangeException("Delay does not allow minus delayFrameCount. delayFrameCount:" + delayFrameCount);
+
+		
+		var beforeTime = DateTime.Now;
+		
+		await GDTask.DelayFrame(delayFrameCount, delayTiming, cancellationToken);
+		
+		return (DateTime.Now - beforeTime).TotalSeconds;
+	}
+}


### PR DESCRIPTION
## Changeling

### Added
- Methods `GDTask<double> GDTask.NextFrameWithDelta(...)`
- Method `GDTask<double> GDTask.DelayFrameWithDelta(...)`

### Changed
- Amount of `GDTask GDTask.NextFrame(...)` overloads reduced with `default` values for `CancellationToken` support


## Proposition

It's useful to know delta of frame-skipping functions, for example for animation progress in async methods.

### Old solution

It was possible with `GDTaskPlayerLoopAutoload.Global.DeltaTime` and `GDTaskPlayerLoopAutoload.Global.PhysicsDeltaTime`

```csharp
await GDTask.NextFrame();
var delta = GDTaskPlayerLoopAutoload.Global.DeltaTime;

// apply it to movement or animation
```

Issues with that:
- works only for skip of one frame
- two lines of code, one for await and one for reading value
- timer loop needs to be set manually
- no solution for new pause timer loops

### New solution

```csharp
var delta = await GDTask.NextFrameWithDelta();

// apply it to movement or animation
```

Why it's cool:
- old methods work the same way, it's an additional module
- working with deltas is the same, as in `_Process` methods, it would be easier for new users
- two times less lines of code
- it's calculating deltas manually, so works with pause loops