### PR TITLE
Add simplified `WaitUntilValueChanged`

### DIFF
--- a/addons/GDTask/GDTask.WaitUntil.cs
+++ b/addons/GDTask/GDTask.WaitUntil.cs
@@ -32,6 +32,11 @@ namespace Fractural.Tasks
                 : WaitUntilValueChangedStandardObjectPromise<T, U>.Create(target, monitorFunction, equalityComparer, monitorTiming, cancellationToken, out token), token);
         }
 
+        public static GDTask<U> WaitUntilValueChanged<U>(Func<U> monitorFunction, PlayerLoopTiming monitorTiming = PlayerLoopTiming.Process, IEqualityComparer<U> equalityComparer = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WaitUntilValueChanged(monitorFunction, static (Func<U> monitorFunction) => monitorFunction(), monitorTiming, equalityComparer, cancellationToken);
+        }
+
         sealed class WaitUntilPromise : IGDTaskSource, IPlayerLoopItem, ITaskPoolNode<WaitUntilPromise>
         {
             static TaskPool<WaitUntilPromise> pool;


### PR DESCRIPTION
This should allow you to change this:
```cs
await GDTask.WaitUntilValueChanged(Time.Singleton, timeInstance => timeInstance.GetTimeDictFromSystem()["minute"]);
```
Into this:
```cs
await GDTask.WaitUntilValueChanged(() => Time.Singleton.GetTimeDictFromSystem()["minute"]);
```