### PR TITLE
Add default parameter for `GDTask.Never`

### DIFF
--- a/addons/GDTask/GDTask.Factory.cs
+++ b/addons/GDTask/GDTask.Factory.cs
@@ -154,7 +154,7 @@ namespace Fractural.Tasks
         /// <summary>
         /// Never complete.
         /// </summary>
-        public static GDTask Never(CancellationToken cancellationToken)
+        public static GDTask Never(CancellationToken cancellationToken = default)
         {
             return new GDTask<AsyncUnit>(new NeverPromise<AsyncUnit>(cancellationToken), 0);
         }
@@ -162,7 +162,7 @@ namespace Fractural.Tasks
         /// <summary>
         /// Never complete.
         /// </summary>
-        public static GDTask<T> Never<T>(CancellationToken cancellationToken)
+        public static GDTask<T> Never<T>(CancellationToken cancellationToken = default)
         {
             return new GDTask<T>(new NeverPromise<T>(cancellationToken), 0);
         }


### PR DESCRIPTION
Makes the cancellation token optional for `GDTask.Never`.

`GDTask.Never` is useful for debugging.